### PR TITLE
[mutable segment: part 2] Add property tests for simple terms dictionary

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 473b58e320bb2678ccf1b5cda610f9c3fbc31861b5ca2b1100646ba0a50f2130
-updated: 2018-02-13T17:55:59.618789-05:00
+hash: 9369108084d181614800f6f01439818f5bcddbcbec9503cf94d6041bdb9291d8
+updated: 2018-02-13T17:57:03.7232-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -70,6 +70,11 @@ testImports:
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
+- name: github.com/leanovate/gopter
+  version: ed879adfa983372d181640d83cbb2851480335d4
+  subpackages:
+  - gen
+  - prop
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 473b58e320bb2678ccf1b5cda610f9c3fbc31861b5ca2b1100646ba0a50f2130
-updated: 2018-02-13T17:54:50.597375-05:00
+updated: 2018-02-13T17:55:59.618789-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 473b58e320bb2678ccf1b5cda610f9c3fbc31861b5ca2b1100646ba0a50f2130
-updated: 2018-02-07T10:18:01.931207-05:00
+updated: 2018-02-13T17:54:50.597375-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -14,7 +14,7 @@ imports:
   subpackages:
   - oleutil
 - name: github.com/golang/snappy
-  version: 553a641470496b2327abcac10b36396bd98e45c9
+  version: d7b1e156f50d3c4664f683603af70e3e47fa0aa2
 - name: github.com/google/codesearch
   version: a45d81b686e85d01f2838439deaf72126ccd5a96
   subpackages:
@@ -24,14 +24,13 @@ imports:
   subpackages:
   - index
 - name: github.com/m3db/m3x
-  version: dbdbd564ff2f64388a641ce61f541eceb7d2e416
+  version: 640bad305baa75986e8b4cbacd23b530374f9c76
   subpackages:
   - checked
   - instrument
   - log
   - pool
   - process
-  - resource
 - name: github.com/mschoch/smat
   version: 90eadee771aeab36e8bf796039b8c261bebebe4f
 - name: github.com/philhofer/fwd
@@ -52,7 +51,7 @@ imports:
 - name: github.com/StackExchange/wmi
   version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/tinylib/msgp
-  version: 03a79185462ad029a6e7e05b2f3f3e0498d0a6c0
+  version: 4b2b2ac00eb1c1f32da648403859ea59033f0bab
   subpackages:
   - msgp
 - name: github.com/uber-go/atomic
@@ -65,22 +64,10 @@ imports:
   - m3/thrift
   - m3/thriftudp
 - name: github.com/willf/bitset
-  version: 1a37ad96e8c1a11b20900a232874843b5174221f
-- name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
-- name: go.uber.org/multierr
-  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
-- name: go.uber.org/zap
-  version: f85c78b1dd998214c5f2138155b320a4a43fbe36
-  subpackages:
-  - buffer
-  - internal/bufferpool
-  - internal/color
-  - internal/exit
-  - zapcore
+  version: 1ea0245d2bc8ce44623f24a1ae162beb06ad8cd6
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,3 +15,7 @@ testImport:
   version: ^1.2.0
   subpackages:
   - require
+- package: github.com/davecgh/go-spew
+  version: ^1.0.0
+- package: github.com/leanovate/gopter
+  version: 0.2.0

--- a/index/segment/mem/simple_terms_dict_test.go
+++ b/index/segment/mem/simple_terms_dict_test.go
@@ -102,12 +102,3 @@ func TestSimpleTermsDictionary(t *testing.T) {
 		},
 	})
 }
-
-func TestTrigramTermsDictionary(t *testing.T) {
-	opts := NewOptions()
-	suite.Run(t, &termsDictionaryTestSuite{
-		fn: func() termsDictionary {
-			return newTrigramTermsDictionary(opts)
-		},
-	})
-}

--- a/index/segment/mem/simple_terms_dict_test.go
+++ b/index/segment/mem/simple_terms_dict_test.go
@@ -25,9 +25,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/m3db/m3ninx/index/segment"
-
 	"github.com/m3db/m3ninx/doc"
+	"github.com/m3db/m3ninx/index/segment"
 
 	"github.com/leanovate/gopter"
 	"github.com/leanovate/gopter/gen"

--- a/index/segment/mem/simple_terms_dict_test.go
+++ b/index/segment/mem/simple_terms_dict_test.go
@@ -21,11 +21,48 @@
 package mem
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+
+	"github.com/m3db/m3ninx/index/segment"
 
 	"github.com/m3db/m3ninx/doc"
 
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
 	"github.com/stretchr/testify/suite"
+)
+
+var (
+	testRandomSeeed        int64 = 42
+	testMinSuccessfulTests       = 1000
+
+	sampleRegexes = []interface{}{
+		`a`,
+		`a.`,
+		`a.b`,
+		`ab`,
+		`a.b.c`,
+		`abc`,
+		`a|^`,
+		`a|b`,
+		`(a)`,
+		`(a)|b`,
+		`a*`,
+		`a+`,
+		`a?`,
+		`a{2}`,
+		`a{2,3}`,
+		`a{2,}`,
+		`a*?`,
+		`a+?`,
+		`a??`,
+		`a{2}?`,
+		`a{2,3}?`,
+		`a{2,}?`,
+	}
 )
 
 type newSimpleTermsDictFn func() *simpleTermsDictionary
@@ -42,56 +79,109 @@ func (t *simpleTermsDictionaryTestSuite) SetupTest() {
 }
 
 func (t *simpleTermsDictionaryTestSuite) TestInsert() {
-	err := t.termsDict.Insert(doc.Field{
-		Name:  []byte("abc"),
-		Value: doc.Value("efg"),
-	}, 1)
-	t.NoError(err)
+	props := getProperties()
+	props.Property(
+		"Inserted fields should be immediately searchable",
+		prop.ForAll(
+			func(f doc.Field, id segment.DocID) (bool, error) {
+				err := t.termsDict.Insert(f, id)
+				if err != nil {
+					return false, fmt.Errorf("unexpected error inserting %v into terms dictionary: %v", f, err)
+				}
 
-	ids, err := t.termsDict.Fetch([]byte("abc"), []byte("efg"), termFetchOptions{false})
-	t.NoError(err)
-	t.NotNil(ids)
-	t.Equal(uint64(1), ids.Size())
-	t.True(ids.Contains(1))
+				ids, err := t.termsDict.Fetch(f.Name, []byte(f.Value), termFetchOptions{false})
+				if err != nil {
+					return false, fmt.Errorf("unexpected error searching for %v in terms dictionary: %v", f, err)
+				}
+
+				if ids == nil {
+					return false, fmt.Errorf("ids of documents matching query should not be nil")
+				}
+				if !ids.Contains(id) {
+					return false, fmt.Errorf("id of new document '%v' is not in list of matching documents", id)
+				}
+
+				return true, nil
+			},
+			genField(),
+			genDocID(),
+		))
+
+	props.TestingRun(t.T())
 }
 
 func (t *simpleTermsDictionaryTestSuite) TestInsertIdempotent() {
-	err := t.termsDict.Insert(doc.Field{
-		Name:  []byte("abc"),
-		Value: doc.Value("efg"),
-	}, 1)
-	t.NoError(err)
-	err = t.termsDict.Insert(doc.Field{
-		Name:  []byte("abc"),
-		Value: doc.Value("efg"),
-	}, 1)
-	t.NoError(err)
+	props := getProperties()
+	props.Property(
+		"Inserting the same field into the terms dictionary should be idempotent",
+		prop.ForAll(
+			func(f doc.Field, id segment.DocID) (bool, error) {
+				err := t.termsDict.Insert(f, id)
+				if err != nil {
+					return false, fmt.Errorf("unexpected error inserting %v into terms dictionary: %v", f, err)
+				}
 
-	ids, err := t.termsDict.Fetch([]byte("abc"), []byte("efg"), termFetchOptions{false})
-	t.NoError(err)
-	t.NotNil(ids)
-	t.Equal(uint64(1), ids.Size())
-	t.True(ids.Contains(1))
+				// Inserting the same field is a valid operation.
+				err = t.termsDict.Insert(f, id)
+				if err != nil {
+					return false, fmt.Errorf("unexpected error re-inserting %v into terms dictionary: %v", f, err)
+				}
+
+				ids, err := t.termsDict.Fetch(f.Name, []byte(f.Value), termFetchOptions{false})
+				if err != nil {
+					return false, fmt.Errorf("unexpected error searching for %v in terms dictionary: %v", f, err)
+				}
+
+				if ids == nil {
+					return false, fmt.Errorf("ids of documents matching query should not be nil")
+				}
+				if !ids.Contains(segment.DocID(id)) {
+					return false, fmt.Errorf("id of new document '%v' is not in list of matching documents", id)
+				}
+
+				return true, nil
+			},
+			genField(),
+			genDocID(),
+		))
+
+	props.TestingRun(t.T())
 }
 
 func (t *simpleTermsDictionaryTestSuite) TestFetchRegex() {
-	err := t.termsDict.Insert(doc.Field{
-		Name:  []byte("abc"),
-		Value: doc.Value("efg"),
-	}, 1)
-	t.NoError(err)
-	err = t.termsDict.Insert(doc.Field{
-		Name:  []byte("abc"),
-		Value: doc.Value("efgh"),
-	}, 2)
-	t.NoError(err)
+	props := getProperties()
+	props.Property(
+		"The dictionary should support regular expression queries",
+		prop.ForAll(
+			func(input fieldAndRegex, id segment.DocID) (bool, error) {
+				var (
+					f  = input.field
+					re = input.re
+				)
+				err := t.termsDict.Insert(f, id)
+				if err != nil {
+					return false, fmt.Errorf("unexpected error inserting %v into terms dictionary: %v", f, err)
+				}
 
-	ids, err := t.termsDict.Fetch([]byte("abc"), []byte("efg.*"), termFetchOptions{true})
-	t.NoError(err)
-	t.NotNil(ids)
-	t.Equal(uint64(2), ids.Size())
-	t.True(ids.Contains(1))
-	t.True(ids.Contains(2))
+				ids, err := t.termsDict.Fetch(f.Name, []byte(re), termFetchOptions{true})
+				if err != nil {
+					return false, fmt.Errorf("unexpected error searching for %v in terms dictionary: %v", f, err)
+				}
+
+				if ids == nil {
+					return false, fmt.Errorf("ids of documents matching query should not be nil")
+				}
+				if !ids.Contains(id) {
+					return false, fmt.Errorf("id of new document '%v' is not in list of matching documents", id)
+				}
+
+				return true, nil
+			},
+			genFieldAndRegex(),
+			genDocID(),
+		))
+
+	props.TestingRun(t.T())
 }
 
 func TestSimpleTermsDictionary(t *testing.T) {
@@ -100,5 +190,66 @@ func TestSimpleTermsDictionary(t *testing.T) {
 		fn: func() *simpleTermsDictionary {
 			return newSimpleTermsDictionary(opts)
 		},
+	})
+}
+
+func getProperties() *gopter.Properties {
+	params := gopter.DefaultTestParameters()
+	params.Rng.Seed(testRandomSeeed)
+	params.MinSuccessfulTests = testMinSuccessfulTests
+	return gopter.NewProperties(params)
+}
+
+func genField() gopter.Gen {
+	return gopter.CombineGens(
+		gen.AnyString(),
+		gen.AnyString(),
+	).Map(func(values []interface{}) doc.Field {
+		var (
+			name  = values[0].(string)
+			value = values[1].(string)
+		)
+		f := doc.Field{
+			Name:  []byte(name),
+			Value: doc.Value(value),
+		}
+		return f
+	})
+}
+
+func genDocID() gopter.Gen {
+	return gen.UInt32().
+		Map(func(value uint32) segment.DocID {
+			return segment.DocID(value)
+		})
+}
+
+type fieldAndRegex struct {
+	field doc.Field
+	re    string
+}
+
+func genFieldAndRegex() gopter.Gen {
+	return gen.OneConstOf(sampleRegexes...).
+		FlatMap(func(value interface{}) gopter.Gen {
+			re := value.(string)
+			return fieldFromRegex(re)
+		}, reflect.TypeOf(fieldAndRegex{}))
+}
+
+func fieldFromRegex(re string) gopter.Gen {
+	return gopter.CombineGens(
+		gen.AnyString(),
+		gen.RegexMatch(re),
+	).Map(func(values []interface{}) fieldAndRegex {
+		var (
+			name  = values[0].(string)
+			value = values[1].(string)
+		)
+		f := doc.Field{
+			Name:  []byte(name),
+			Value: doc.Value(value),
+		}
+		return fieldAndRegex{field: f, re: re}
 	})
 }

--- a/index/segment/mem/simple_terms_dict_test.go
+++ b/index/segment/mem/simple_terms_dict_test.go
@@ -102,3 +102,12 @@ func TestSimpleTermsDictionary(t *testing.T) {
 		},
 	})
 }
+
+func TestTrigramTermsDictionary(t *testing.T) {
+	opts := NewOptions()
+	suite.Run(t, &termsDictionaryTestSuite{
+		fn: func() termsDictionary {
+			return newTrigramTermsDictionary(opts)
+		},
+	})
+}


### PR DESCRIPTION
This diff expands the current test suite for the simple terms dictionary to include property tests for its observable behavior.

cc @prateek 