### PR TITLE
Add public idx package

### DIFF
--- a/idx/query.go
+++ b/idx/query.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package idx
+
+import (
+	"github.com/m3db/m3ninx/search"
+	"github.com/m3db/m3ninx/search/query"
+)
+
+// Query encapsulates a search query for an index.
+type Query struct {
+	query search.Query
+}
+
+// NewTermQuery returns a new query for finding documents which match a term exactly.
+func NewTermQuery(field, term []byte) Query {
+	return Query{
+		query: query.NewTermQuery(field, term),
+	}
+}
+
+// NewRegexpQuery returns a new query for finding documents which match a regular expression.
+func NewRegexpQuery(field, regexp []byte) (Query, error) {
+	q, err := query.NewRegexpQuery(field, regexp)
+	if err != nil {
+		return Query{}, err
+	}
+	return Query{
+		query: q,
+	}, nil
+}
+
+// NewConjunctionQuery returns a new query for finding documents which match each of the
+// given queries.
+func NewConjunctionQuery(queries ...Query) (Query, error) {
+	qs := make([]search.Query, 0, len(queries))
+	for _, q := range queries {
+		qs = append(qs, q.query)
+	}
+	return Query{
+		query: query.NewConjuctionQuery(qs),
+	}, nil
+}
+
+// NewDisjunctionQuery returns a new query for finding documents which match at least one
+// of the given queries.
+func NewDisjunctionQuery(queries ...Query) (Query, error) {
+	qs := make([]search.Query, 0, len(queries))
+	for _, q := range queries {
+		qs = append(qs, q.query)
+	}
+	return Query{
+		query: query.NewDisjuctionQuery(qs),
+	}, nil
+}

--- a/idx/types.go
+++ b/idx/types.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package idx
+
+import (
+	"github.com/m3db/m3ninx/doc"
+)
+
+// Index is an inverted index.
+type Index interface {
+	// Insert inserts a document into the index.
+	Insert(d doc.Document) error
+
+	// Searcher returns a Searcher over a point-in-time view of the index.
+	Searcher() (Searcher, error)
+
+	// Close closes the index.
+	Close() error
+}
+
+// Searcher provides search over a point-in-time view of an index.
+type Searcher interface {
+	Search(q Query) (doc.Iterator, error)
+
+	Close() error
+}


### PR DESCRIPTION
This diff adds the `idx` package which will contain all the public facing interfaces that a client would interact with. I haven't updated the package structure but will likely leave until what we decide on what the `idx` package should look like.

cc @prateek 