### PR TITLE
[query] Set number of readers in conjunction and disjunction searchers

### DIFF
--- a/search/query/conjunction.go
+++ b/search/query/conjunction.go
@@ -69,5 +69,5 @@ func (q *ConjuctionQuery) Searcher(rs index.Readers) (search.Searcher, error) {
 		srs = append(srs, sr)
 	}
 
-	return searcher.NewConjunctionSearcher(srs)
+	return searcher.NewConjunctionSearcher(len(rs), srs)
 }

--- a/search/query/disjunction.go
+++ b/search/query/disjunction.go
@@ -69,5 +69,5 @@ func (q *DisjuctionQuery) Searcher(rs index.Readers) (search.Searcher, error) {
 		srs = append(srs, sr)
 	}
 
-	return searcher.NewDisjunctionSearcher(srs)
+	return searcher.NewDisjunctionSearcher(len(rs), srs)
 }

--- a/search/searcher/conjunction.go
+++ b/search/searcher/conjunction.go
@@ -26,8 +26,8 @@ import (
 )
 
 type conjunctionSearcher struct {
-	searchers search.Searchers
-	len       int
+	searchers  search.Searchers
+	numReaders int
 
 	idx  int
 	curr postings.List
@@ -42,14 +42,14 @@ func NewConjunctionSearcher(numReaders int, searchers search.Searchers) (search.
 	}
 
 	return &conjunctionSearcher{
-		searchers: searchers,
-		len:       numReaders,
-		idx:       -1,
+		searchers:  searchers,
+		numReaders: numReaders,
+		idx:        -1,
 	}, nil
 }
 
 func (s *conjunctionSearcher) Next() bool {
-	if s.err != nil || s.idx == s.len-1 {
+	if s.err != nil || s.idx == s.numReaders-1 {
 		return false
 	}
 
@@ -92,5 +92,5 @@ func (s *conjunctionSearcher) Err() error {
 }
 
 func (s *conjunctionSearcher) NumReaders() int {
-	return s.len
+	return s.numReaders
 }

--- a/search/searcher/conjunction.go
+++ b/search/searcher/conjunction.go
@@ -36,14 +36,14 @@ type conjunctionSearcher struct {
 
 // NewConjunctionSearcher returns a new Searcher which matches documents which match each
 // of the given Searchers. It is not safe for concurrent access.
-func NewConjunctionSearcher(ss search.Searchers) (search.Searcher, error) {
-	if err := validateSearchers(ss); err != nil {
+func NewConjunctionSearcher(numReaders int, searchers search.Searchers) (search.Searcher, error) {
+	if err := validateSearchers(numReaders, searchers); err != nil {
 		return nil, err
 	}
 
 	return &conjunctionSearcher{
-		searchers: ss,
-		len:       len(ss),
+		searchers: searchers,
+		len:       numReaders,
 		idx:       -1,
 	}, nil
 }

--- a/search/searcher/disjunction.go
+++ b/search/searcher/disjunction.go
@@ -36,14 +36,14 @@ type disjunctionSearcher struct {
 
 // NewDisjunctionSearcher returns a new Searcher which matches documents which are matched
 // by any of the given Searchers. It is not safe for concurrent access.
-func NewDisjunctionSearcher(ss search.Searchers) (search.Searcher, error) {
-	if err := validateSearchers(ss); err != nil {
+func NewDisjunctionSearcher(numReaders int, searchers search.Searchers) (search.Searcher, error) {
+	if err := validateSearchers(numReaders, searchers); err != nil {
 		return nil, err
 	}
 
 	return &disjunctionSearcher{
-		searchers: ss,
-		len:       len(ss),
+		searchers: searchers,
+		len:       numReaders,
 		idx:       -1,
 	}, nil
 }

--- a/search/searcher/disjunction.go
+++ b/search/searcher/disjunction.go
@@ -26,8 +26,8 @@ import (
 )
 
 type disjunctionSearcher struct {
-	searchers search.Searchers
-	len       int
+	searchers  search.Searchers
+	numReaders int
 
 	idx  int
 	curr postings.List
@@ -42,14 +42,14 @@ func NewDisjunctionSearcher(numReaders int, searchers search.Searchers) (search.
 	}
 
 	return &disjunctionSearcher{
-		searchers: searchers,
-		len:       numReaders,
-		idx:       -1,
+		searchers:  searchers,
+		numReaders: numReaders,
+		idx:        -1,
 	}, nil
 }
 
 func (s *disjunctionSearcher) Next() bool {
-	if s.err != nil || s.idx == s.len-1 {
+	if s.err != nil || s.idx == s.numReaders-1 {
 		return false
 	}
 
@@ -87,5 +87,5 @@ func (s *disjunctionSearcher) Err() error {
 }
 
 func (s *disjunctionSearcher) NumReaders() int {
-	return s.len
+	return s.numReaders
 }

--- a/search/searcher/util.go
+++ b/search/searcher/util.go
@@ -22,23 +22,20 @@ package searcher
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/m3db/m3ninx/search"
 )
 
 var (
-	errSearchersNumReadersUnequal = errors.New("searchers have different number of readers")
-	errSearcherTooShort           = errors.New("searcher did not contain enough postings lists")
+	errSearcherTooShort = errors.New("searcher did not contain enough postings lists")
 )
 
-func validateSearchers(ss search.Searchers) error {
-	var numReaders int
-	if len(ss) > 0 {
-		numReaders = ss[0].NumReaders()
-		for _, s := range ss[1:] {
-			if s.NumReaders() != numReaders {
-				return errSearchersNumReadersUnequal
-			}
+func validateSearchers(numReaders int, searchers search.Searchers) error {
+	for _, s := range searchers {
+		n := s.NumReaders()
+		if n != numReaders {
+			return fmt.Errorf("searcher has %v readers, expected %v", n, numReaders)
 		}
 	}
 	return nil

--- a/search/searcher/util_test.go
+++ b/search/searcher/util_test.go
@@ -52,25 +52,28 @@ func TestValidateSearchers(t *testing.T) {
 	)
 
 	tests := []struct {
-		name      string
-		ss        search.Searchers
-		expectErr bool
+		name       string
+		numReaders int
+		searchers  search.Searchers
+		expectErr  bool
 	}{
 		{
-			name:      "all searchers have the same length",
-			ss:        firstTestSeachers,
-			expectErr: false,
+			name:       "valid",
+			numReaders: 3,
+			searchers:  firstTestSeachers,
+			expectErr:  false,
 		},
 		{
-			name:      "all searchers do not have the same length",
-			ss:        secondTestSeachers,
-			expectErr: true,
+			name:       "invalid",
+			numReaders: 3,
+			searchers:  secondTestSeachers,
+			expectErr:  true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateSearchers(test.ss)
+			err := validateSearchers(test.numReaders, test.searchers)
 			if test.expectErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
Previously we set the length of the conjunction and disjunction searchers to be the number of searchers they contained instead of the number of readers the searchers were searching over. The bug was hidden because the test used an equal number of searchers and readers. This diff fixes the bug and ensures the test case uses a different of searchers and readers.