### PR TITLE
Add access to fieldnames/values/postingslists

### DIFF
--- a/.excludecoverage
+++ b/.excludecoverage
@@ -1,0 +1,7 @@
+_mock.go
+_gen.go
+generated/
+vendor/
+tools/
+integration/
+testgen/

--- a/generated-source-files.mk
+++ b/generated-source-files.mk
@@ -1,6 +1,6 @@
 m3x_package          := github.com/m3db/m3x
 m3x_package_path     := $(gopath_prefix)/$(m3x_package)
-m3x_package_min_ver  := 65607134244391c697a9d6c971fbdb8256132f03
+m3x_package_min_ver  := 6148700dde75adcdcc27d16fb68cee2d9d9126d8
 
 .PHONY: install-m3x-repo
 install-m3x-repo: install-glide install-generics-bin

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 17ce3389aaa2036a637bb896875b70f0884cde9d9fe97171aced5febcc3f0152
-updated: 2018-05-09T15:00:43.035904-04:00
+hash: 48d27bf72917e4a2b50a173cb9716ddf64adda9593d463194175059014eb72f6
+updated: 2018-05-12T11:51:18.097399435-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -22,7 +22,7 @@ imports:
 - name: github.com/m3db/codesearch
   version: a45d81b686e85d01f2838439deaf72126ccd5a96
 - name: github.com/m3db/m3x
-  version: d0873c0b327bee1a4a47f1d84263a6edaebbbf66
+  version: 6148700dde75adcdcc27d16fb68cee2d9d9126d8
   subpackages:
   - checked
   - errors
@@ -37,7 +37,7 @@ imports:
 - name: github.com/philhofer/fwd
   version: bb6d471dc95d4fe11e432687f8b70ff496cf3136
 - name: github.com/RoaringBitmap/roaring
-  version: 4bbba8874933b985c9160558fddea525dde73e63
+  version: 1a28a7fa985680f9f4e1644c0a857ec359a444b0
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/tinylib/msgp
@@ -60,7 +60,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 35aad584952c3e7020db7b839f6b102de6271f89
+  version: f85c78b1dd998214c5f2138155b320a4a43fbe36
   subpackages:
   - buffer
   - internal/bufferpool
@@ -68,7 +68,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: ab5485076ff3407ad2d02db054635913f017b0ed
+  version: 054b33e6527139ad5b1ec2f6232c3b175bd9a30c
   subpackages:
   - context
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,9 +2,9 @@ package: github.com/m3db/m3ninx
 import:
 # need to pin this version until we're using 1.9
 - package: github.com/RoaringBitmap/roaring
-  version: 0.3.9
+  version: 0.4.7
 - package: github.com/m3db/m3x
-  version: d0873c0b327bee1a4a47f1d84263a6edaebbbf66
+  version: 6148700dde75adcdcc27d16fb68cee2d9d9126d8
   subpackages:
   - instrument
   - generics

--- a/index/segment/mem/concurrent_postings_map.go
+++ b/index/segment/mem/concurrent_postings_map.go
@@ -77,6 +77,17 @@ func (m *concurrentPostingsMap) Add(key []byte, id postings.ID) {
 	p.Insert(id)
 }
 
+// Keys returns the keys known to the map.
+func (m *concurrentPostingsMap) Keys() [][]byte {
+	m.RLock()
+	defer m.RUnlock()
+	keys := make([][]byte, 0, m.Len())
+	for _, entry := range m.Iter() {
+		keys = append(keys, entry.Key())
+	}
+	return keys
+}
+
 // Get returns the postings.List backing `key`.
 func (m *concurrentPostingsMap) Get(key []byte) (postings.List, bool) {
 	m.RLock()

--- a/index/segment/mem/terms_dict.go
+++ b/index/segment/mem/terms_dict.go
@@ -64,6 +64,26 @@ func (d *termsDict) MatchTerm(field, term []byte) postings.List {
 	return pl
 }
 
+func (d *termsDict) Fields() [][]byte {
+	d.fields.RLock()
+	defer d.fields.RUnlock()
+	fields := make([][]byte, 0, d.fields.Len())
+	for _, entry := range d.fields.Iter() {
+		fields = append(fields, entry.Key())
+	}
+	return fields
+}
+
+func (d *termsDict) Terms(field []byte) [][]byte {
+	d.fields.RLock()
+	defer d.fields.RUnlock()
+	values, ok := d.fields.Get(field)
+	if !ok {
+		return nil
+	}
+	return values.Keys()
+}
+
 func (d *termsDict) matchTerm(field, term []byte) (postings.List, bool) {
 	d.fields.RLock()
 	postingsMap, ok := d.fields.Get(field)

--- a/index/segment/mem/types.go
+++ b/index/segment/mem/types.go
@@ -43,6 +43,12 @@ type termsDictionary interface {
 	// MatchRegexp returns the postings list corresponding to documents which match the
 	// given egular expression.
 	MatchRegexp(field, regexp []byte, compiled *re.Regexp) postings.List
+
+	// Fields returns the list of known fields.
+	Fields() [][]byte
+
+	// Terms returns the list of known terms values for the given field.
+	Terms(field []byte) [][]byte
 }
 
 // ReadableSegment is an internal interface for reading from a segment.

--- a/index/segment/segment_mock.go
+++ b/index/segment/segment_mock.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/m3db/m3ninx/doc"
 	"github.com/m3db/m3ninx/index"
+	"github.com/m3db/m3ninx/postings"
 
 	"github.com/golang/mock/gomock"
 )
@@ -81,6 +82,32 @@ func (mr *MockSegmentMockRecorder) ContainsID(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsID", reflect.TypeOf((*MockSegment)(nil).ContainsID), arg0)
 }
 
+// Fields mocks base method
+func (m *MockSegment) Fields() ([][]byte, error) {
+	ret := m.ctrl.Call(m, "Fields")
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Fields indicates an expected call of Fields
+func (mr *MockSegmentMockRecorder) Fields() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fields", reflect.TypeOf((*MockSegment)(nil).Fields))
+}
+
+// MatchTerm mocks base method
+func (m *MockSegment) MatchTerm(arg0, arg1 []byte) (postings.List, error) {
+	ret := m.ctrl.Call(m, "MatchTerm", arg0, arg1)
+	ret0, _ := ret[0].(postings.List)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MatchTerm indicates an expected call of MatchTerm
+func (mr *MockSegmentMockRecorder) MatchTerm(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTerm", reflect.TypeOf((*MockSegment)(nil).MatchTerm), arg0, arg1)
+}
+
 // Reader mocks base method
 func (m *MockSegment) Reader() (index.Reader, error) {
 	ret := m.ctrl.Call(m, "Reader")
@@ -104,6 +131,19 @@ func (m *MockSegment) Size() int64 {
 // Size indicates an expected call of Size
 func (mr *MockSegmentMockRecorder) Size() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockSegment)(nil).Size))
+}
+
+// Terms mocks base method
+func (m *MockSegment) Terms(arg0 []byte) ([][]byte, error) {
+	ret := m.ctrl.Call(m, "Terms", arg0)
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Terms indicates an expected call of Terms
+func (mr *MockSegmentMockRecorder) Terms(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terms", reflect.TypeOf((*MockSegment)(nil).Terms), arg0)
 }
 
 // MockMutableSegment is a mock of MutableSegment interface
@@ -154,6 +194,19 @@ func (mr *MockMutableSegmentMockRecorder) ContainsID(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsID", reflect.TypeOf((*MockMutableSegment)(nil).ContainsID), arg0)
 }
 
+// Fields mocks base method
+func (m *MockMutableSegment) Fields() ([][]byte, error) {
+	ret := m.ctrl.Call(m, "Fields")
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Fields indicates an expected call of Fields
+func (mr *MockMutableSegmentMockRecorder) Fields() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fields", reflect.TypeOf((*MockMutableSegment)(nil).Fields))
+}
+
 // Insert mocks base method
 func (m *MockMutableSegment) Insert(arg0 doc.Document) ([]byte, error) {
 	ret := m.ctrl.Call(m, "Insert", arg0)
@@ -179,6 +232,19 @@ func (mr *MockMutableSegmentMockRecorder) InsertBatch(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBatch", reflect.TypeOf((*MockMutableSegment)(nil).InsertBatch), arg0)
 }
 
+// MatchTerm mocks base method
+func (m *MockMutableSegment) MatchTerm(arg0, arg1 []byte) (postings.List, error) {
+	ret := m.ctrl.Call(m, "MatchTerm", arg0, arg1)
+	ret0, _ := ret[0].(postings.List)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MatchTerm indicates an expected call of MatchTerm
+func (mr *MockMutableSegmentMockRecorder) MatchTerm(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTerm", reflect.TypeOf((*MockMutableSegment)(nil).MatchTerm), arg0, arg1)
+}
+
 // Reader mocks base method
 func (m *MockMutableSegment) Reader() (index.Reader, error) {
 	ret := m.ctrl.Call(m, "Reader")
@@ -192,6 +258,19 @@ func (mr *MockMutableSegmentMockRecorder) Reader() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reader", reflect.TypeOf((*MockMutableSegment)(nil).Reader))
 }
 
+// Seal mocks base method
+func (m *MockMutableSegment) Seal() (Segment, error) {
+	ret := m.ctrl.Call(m, "Seal")
+	ret0, _ := ret[0].(Segment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Seal indicates an expected call of Seal
+func (mr *MockMutableSegmentMockRecorder) Seal() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seal", reflect.TypeOf((*MockMutableSegment)(nil).Seal))
+}
+
 // Size mocks base method
 func (m *MockMutableSegment) Size() int64 {
 	ret := m.ctrl.Call(m, "Size")
@@ -202,4 +281,17 @@ func (m *MockMutableSegment) Size() int64 {
 // Size indicates an expected call of Size
 func (mr *MockMutableSegmentMockRecorder) Size() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockMutableSegment)(nil).Size))
+}
+
+// Terms mocks base method
+func (m *MockMutableSegment) Terms(arg0 []byte) ([][]byte, error) {
+	ret := m.ctrl.Call(m, "Terms", arg0)
+	ret0, _ := ret[0].([][]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Terms indicates an expected call of Terms
+func (mr *MockMutableSegmentMockRecorder) Terms(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Terms", reflect.TypeOf((*MockMutableSegment)(nil).Terms), arg0)
 }

--- a/index/segment/types.go
+++ b/index/segment/types.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 
 	"github.com/m3db/m3ninx/index"
+	"github.com/m3db/m3ninx/postings"
 )
 
 var (
@@ -46,10 +47,22 @@ type Segment interface {
 
 	// Close closes the segment and releases any internal resources.
 	Close() error
+
+	// Fields returns the list of known fields.
+	Fields() ([][]byte, error)
+
+	// Terms returns the list of known terms values for the given field.
+	Terms(field []byte) ([][]byte, error)
+
+	// MatchTerm returns postings list for the given field and term.
+	MatchTerm(field, term []byte) (postings.List, error)
 }
 
 // MutableSegment is a segment which can be updated.
 type MutableSegment interface {
 	Segment
 	index.Writer
+
+	// Seal marks the Mutable Segment immutable.
+	Seal() (Segment, error)
 }

--- a/search/search_mock.go
+++ b/search/search_mock.go
@@ -143,31 +143,6 @@ func (mr *MockQueryMockRecorder) Equal(q interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Equal", reflect.TypeOf((*MockQuery)(nil).Equal), q)
 }
 
-// Marshal mocks base method
-func (m *MockQuery) Marshal() ([]byte, error) {
-	ret := m.ctrl.Call(m, "Marshal")
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Marshal indicates an expected call of Marshal
-func (mr *MockQueryMockRecorder) Marshal() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshal", reflect.TypeOf((*MockQuery)(nil).Marshal))
-}
-
-// Unmarshal mocks base method
-func (m *MockQuery) Unmarshal(data []byte) error {
-	ret := m.ctrl.Call(m, "Unmarshal", data)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Unmarshal indicates an expected call of Unmarshal
-func (mr *MockQueryMockRecorder) Unmarshal(data interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmarshal", reflect.TypeOf((*MockQuery)(nil).Unmarshal), data)
-}
-
 // ToProto mocks base method
 func (m *MockQuery) ToProto() *querypb.Query {
 	ret := m.ctrl.Call(m, "ToProto")


### PR DESCRIPTION
- Add accessors to segment to prepare for immutable segment
- Codecov excludes for generated files
- mock-gen'd updates
- update m3x/roaring versions 