### PR TITLE
[query] Add String method to idx.Query

### DIFF
--- a/idx/query.go
+++ b/idx/query.go
@@ -30,6 +30,10 @@ type Query struct {
 	query search.Query
 }
 
+func (q Query) String() string {
+	return q.query.String()
+}
+
 // NewTermQuery returns a new query for finding documents which match a term exactly.
 func NewTermQuery(field, term []byte) Query {
 	return Query{


### PR DESCRIPTION
Add a `String` method to `idx.Query` to pretty-print queries. Resolves #89 